### PR TITLE
Create delete-group button

### DIFF
--- a/app.py
+++ b/app.py
@@ -19,6 +19,7 @@ else:
     app.config.from_object('config.DevelopmentConfig')
 
 connect_db(app)
+db.drop_all()
 db.create_all()
 
 app.register_blueprint(landing_routes)

--- a/models.py
+++ b/models.py
@@ -1,5 +1,6 @@
 from flask_sqlalchemy import SQLAlchemy
 from flask_bcrypt import Bcrypt
+from sqlalchemy.orm import backref
 
 bcrypt = Bcrypt()
 db = SQLAlchemy()
@@ -48,6 +49,16 @@ class User(db.Model):
             return False
 
 
+class UserGroup(db.Model):
+    """Maps users to their groups."""
+
+    __tablename__ = 'users_groups'
+
+    id = db.Column(db.Integer, primary_key=True, autoincrement=True)
+    user_id = db.Column(db.Integer, db.ForeignKey('users.id', ondelete='CASCADE'))
+    group_id = db.Column(db.Integer, db.ForeignKey('groups.id', ondelete='CASCADE'))
+
+
 class Group(db.Model):
     """Group page."""
 
@@ -56,17 +67,9 @@ class Group(db.Model):
     id = db.Column(db.Integer, primary_key=True, autoincrement=True)
     name = db.Column(db.String, nullable=False)
     description = db.Column(db.String)
-    admin_id = db.Column(db.Integer, db.ForeignKey('users.id'))
+    admin_id = db.Column(db.Integer, db.ForeignKey('users.id', ondelete='CASCADE'))
 
-
-class UserGroup(db.Model):
-    """Maps users to their groups."""
-
-    __tablename__ = 'user_groups'
-
-    id = db.Column(db.Integer, primary_key=True, autoincrement=True)
-    user_id = db.Column(db.Integer, db.ForeignKey('users.id'))
-    group_id = db.Column(db.Integer, db.ForeignKey('groups.id'))
+    user = db.relationship('User', backref=backref('groups', cascade='all, delete-orphan'))
 
 
 class Post(db.Model):
@@ -75,12 +78,12 @@ class Post(db.Model):
     __tablename__ = 'posts'
 
     id = db.Column(db.Integer, primary_key=True, autoincrement=True)
-    user_id = db.Column(db.Integer, db.ForeignKey('users.id'))
-    group_id = db.Column(db.Integer, db.ForeignKey('groups.id'))
+    user_id = db.Column(db.Integer, db.ForeignKey('users.id', ondelete='CASCADE'))
+    group_id = db.Column(db.Integer, db.ForeignKey('groups.id', ondelete='CASCADE'))
     content = db.Column(db.String)
     spotify_id = db.Column(db.String)
     is_reply = db.Column(db.Boolean, default=False)
-    reply_to = db.Column(db.Integer, db.ForeignKey('posts.id'))
+    reply_to = db.Column(db.Integer, db.ForeignKey('posts.id', ondelete='CASCADE'))
 
 
 def connect_db(app):

--- a/routes/group_routes.py
+++ b/routes/group_routes.py
@@ -61,3 +61,15 @@ def edit_group(user_id, group_id):
         return redirect(f"/user/{user_id}/group/{group_id}")
 
     return render_template("edit-group.html", user=user, group=group, form=form)
+
+
+@group_routes.route("/user/<int:user_id>/group/<int:group_id>/delete", methods=["GET", "DELETE"])
+@login_required
+def delete_group(user_id, group_id):
+    """Delete group."""
+
+    group = Group.query.get(group_id)
+    db.session.delete(group)
+    db.session.commit()
+
+    return redirect(f"/user/{user_id}")

--- a/static/group.css
+++ b/static/group.css
@@ -23,3 +23,9 @@
   background: #4278a3;
   color: #fff;
 }
+
+.delete-btn {
+  position: relative;
+  background: #c74545;
+  color: #fff;
+}

--- a/templates/group_page/edit-group.html
+++ b/templates/group_page/edit-group.html
@@ -17,7 +17,7 @@
     <br />
     {% endfor %}
     <!--  -->
-    <button type="submit">Create group</button>
+    <button type="submit">Save</button>
   </form>
 </div>
 {% endblock %}

--- a/templates/group_page/group.html
+++ b/templates/group_page/group.html
@@ -28,10 +28,17 @@
   <!-- admin buttons -->
   <form
     class="group-actions-form"
-    method="PATCH"
     action="/user/{{ user.id }}/group/{{ group.id }}/edit"
   >
     <button type="submit" class="edit-btn">Edit group</button>
+  </form>
+  <form
+    class="group-actions-form"
+    method="DELETE"
+    action="/user/{{ user.id }}/group/{{ group.id }}/delete"
+    onSubmit="return confirm('Are you sure you wish to delete?');"
+  >
+    <button type="submit" class="delete-btn">Delete group</button>
   </form>
   {% endif %}
 </div>

--- a/tests/test_group_routes.py
+++ b/tests/test_group_routes.py
@@ -89,11 +89,11 @@ class TestGroupRoutes(TestCase):
             self.assertIn('Leave group', html)
 
             # check db
-            user3_in_group = UserGroup.query.filter_by(user_id=3).all()
-            user_group_len = UserGroup.query.filter_by(group_id=1).all()
+            user3_in_group = UserGroup.query.filter_by(user_id=3).count()
+            user_group_len = UserGroup.query.filter_by(group_id=1).count()
 
-            self.assertEqual(len(user3_in_group), 1)
-            self.assertEqual(len(user_group_len), 2)
+            self.assertEqual(user3_in_group, 1)
+            self.assertEqual(user_group_len, 2)
 
 
     def test_leave_group(self):
@@ -116,14 +116,14 @@ class TestGroupRoutes(TestCase):
 
             # check db
             client.post('/user/3/group/1/join')
-            user3_in_group = UserGroup.query.filter_by(user_id=3).all()
+            user3_in_group = UserGroup.query.filter_by(user_id=3).count()
 
-            self.assertEqual(len(user3_in_group), 1)
+            self.assertEqual(user3_in_group, 1)
 
             client.delete('/user/3/group/1/leave')
-            user3_not_in_group = UserGroup.query.filter_by(user_id=3).all()
+            user3_not_in_group = UserGroup.query.filter_by(user_id=3).count()
 
-            self.assertEqual(len(user3_not_in_group), 0)
+            self.assertEqual(user3_not_in_group, 0)
 
 
     def test_edit_group(self):
@@ -148,3 +148,19 @@ class TestGroupRoutes(TestCase):
 
             self.assertEqual(group.name, 'Test Group Edited')
             self.assertEqual(group.description, "It really is for testing!")
+
+
+    def test_delete_group(self):
+        """Test deleting a group works."""
+
+        with app.test_client() as client:
+            # follow_redirects=true
+            redirect_resp = client.delete('/user/1/group/1/delete', follow_redirects=True)
+            html = redirect_resp.get_data(as_text=True)
+
+            self.assertEqual(redirect_resp.status_code, 200)
+            self.assertIn("Browse groups", html)
+
+            # check db
+            group = Group.query.filter_by(id=1).first()
+            self.assertEqual(group, None)


### PR DESCRIPTION
### What does this PR do?
- Creates a delete-group button for group admins.
- Pop-confirmation on page for delete.
- Sets up cascade on delete in database.

### Description of task to be completed
- Closes #43 

### How to test
- Navigate to root directory and run <code>python3 -m unittest tests/test_group_routes.py</code> in terminal.