### PR TITLE
Add songs to group posts

### DIFF
--- a/config.py
+++ b/config.py
@@ -28,6 +28,8 @@ class TestingConfig(Config):
     ENV = 'testing'
     LOGIN_DISABLED = True # https://flask-login.readthedocs.io/en/latest/
     WTF_CSRF_ENABLED = False
+    SESSION_COOKIE_DOMAIN = None
+    PRESERVE_CONTEXT_ON_EXCEPTION = False # https://github.com/jarus/flask-testing/issues/21
 
 
 class ProductionConfig(Config):

--- a/helpers.py
+++ b/helpers.py
@@ -1,0 +1,10 @@
+from flask import session
+
+def clear_session():
+        """Clears session of selected Spotify song data."""
+
+        session.pop("track_image", None)
+        session.pop("track_name", None)
+        session.pop("track_artist", None)
+        session.pop("track_link", None)
+        session.pop("track_preview", None)

--- a/models.py
+++ b/models.py
@@ -81,9 +81,15 @@ class Post(db.Model):
     user_id = db.Column(db.Integer, db.ForeignKey('users.id', ondelete='CASCADE'))
     group_id = db.Column(db.Integer, db.ForeignKey('groups.id', ondelete='CASCADE'))
     content = db.Column(db.String, nullable=False)
-    spotify_id = db.Column(db.String)
+    s_image = db.Column(db.String)
+    s_name = db.Column(db.String)
+    s_artist = db.Column(db.String)
+    s_link = db.Column(db.String)
+    s_preview = db.Column(db.String)
     is_reply = db.Column(db.Boolean, default=False)
     reply_to = db.Column(db.Integer, db.ForeignKey('posts.id', ondelete='CASCADE'))
+
+    user = db.relationship('User', backref=backref('posts', cascade='all, delete-orphan'))
 
 
 def connect_db(app):

--- a/routes/group_routes.py
+++ b/routes/group_routes.py
@@ -57,7 +57,7 @@ def post(user_id, group_id):
         db.session.add(newPost)
         db.session.commit()
         clear_session()
-    
+
         return redirect(f"/user/{user_id}/group/{group_id}")
 
 

--- a/routes/group_routes.py
+++ b/routes/group_routes.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, render_template, redirect, session
+from flask import Blueprint, render_template, redirect, session, request
 from flask_login.utils import login_required
 import requests
 from urllib.parse import urlencode
@@ -6,6 +6,7 @@ from forms import PostForm, GroupForm, SpotifySearchForm
 from models import db, User, Group, UserGroup, Post
 from spotify_api_auth import SpotifyAPI
 from api_keys import CLIENT_ID, CLIENT_SECRET
+from helpers import clear_session
 
 group_routes = Blueprint("group_routes", __name__, static_folder="../static", template_folder="../templates/group_page")
 
@@ -20,17 +21,44 @@ def group_page(user_id, group_id):
     user_in_group = UserGroup.query.filter(UserGroup.user_id == user_id, UserGroup.group_id == group_id).first() # determine if user is in group (but not admin). Used to choose which action buttons to display.
     posts = Post.query.filter(Post.group_id == group_id).all()
 
-    form = PostForm()
+    post_form = PostForm()
 
-    if form.validate_on_submit():
-        content = form.content.data
-        newPost = Post(content=content, user_id=user_id, group_id=group_id)
+    # remove selected song from session storage on button click
+    if request.method == 'POST' and request.form["btn"] == "delete":
+        clear_session()
+
+    return render_template("group.html", user=user, group=group, user_in_group=user_in_group, posts=posts, post_form=post_form, clear_session=clear_session)
+
+
+@group_routes.route("/user/<int:user_id>/group/<int:group_id>/post", methods=["POST"])
+@login_required
+def post(user_id, group_id):
+    """Create post."""
+
+    post_form = PostForm()
+
+    if post_form.validate_on_submit():
+        content = post_form.content.data
+
+        if session.get('track_name'):
+            print('SONG IN SESSION I REPEAT')
+            s_image=session.get('track_image')
+            s_name=session.get('track_name')
+            s_artist=session.get('track_artist')
+            s_link=session.get('track_link')
+            s_preview=session.get('track_preview')
+
+            newPost = Post(content=content, user_id=user_id, group_id=group_id, s_image=s_image, s_name=s_name, s_artist=s_artist, s_link=s_link, s_preview=s_preview)
+
+        else:
+            print('NOTHING IN SESSION I REPEAT')
+            newPost = Post(content=content, user_id=user_id, group_id=group_id)
+
         db.session.add(newPost)
         db.session.commit()
-
+        clear_session()
+    
         return redirect(f"/user/{user_id}/group/{group_id}")
-
-    return render_template("group.html", user=user, group=group, user_in_group=user_in_group, posts=posts, form=form)
 
 
 @group_routes.route("/user/<int:user_id>/group/<int:group_id>/join", methods=["POST"])
@@ -91,14 +119,16 @@ def delete_group(user_id, group_id):
 @group_routes.route("/user/<int:user_id>/group/<int:group_id>/search_spotify", methods=["GET", "POST"])
 @login_required
 def search_spotify(user_id, group_id):
+    """Search Spotify API for songs."""
 
     user = User.query.get(user_id)
     group = Group.query.get(group_id)
 
-    form = SpotifySearchForm()
+    search_form = SpotifySearchForm()
 
-    if form.validate_on_submit():
-        query = form.query.data
+    # spotify search form
+    if search_form.validate_on_submit() and request.form["btn"] == "search":
+        query = search_form.query.data
         client = SpotifyAPI(CLIENT_ID, CLIENT_SECRET)
         client.authorize()
         token = client.access_token
@@ -111,9 +141,19 @@ def search_spotify(user_id, group_id):
 
         r = requests.get(lookup_url, headers=headers)
         resp = r.json()
-        session['track_results'] = resp["tracks"]["items"]
+        session["track_results"] = resp["tracks"]["items"]
+
+    # add data from selected song to session
+    if request.method == 'POST' and request.form["btn"] == "select":
+        session['track_image'] = request.form.get('track_image')
+        session['track_name'] = request.form.get('track_name')
+        session['track_artist'] = request.form.get('track_artist')
+        session['track_link'] = request.form.get('track_link')
+        session['track_preview'] = request.form.get('track_preview')
+
+        return redirect(f"/user/{user_id}/group/{group_id}")
 
     if (session.get('track_results') != None):
-        return render_template("search_spotify.html", user=user, group=group, form=form, tracks=session.get('track_results'))
+        return render_template("search_spotify.html", user=user, group=group, search_form=search_form, post_form=PostForm(), tracks=session.get('track_results'))
     else:
-        return render_template("search_spotify.html", user=user, group=group, form=form)
+        return render_template("search_spotify.html", user=user, group=group, search_form=search_form, post_form=PostForm())

--- a/routes/landing_routes.py
+++ b/routes/landing_routes.py
@@ -2,6 +2,7 @@ from flask import Blueprint, render_template, redirect
 from flask_login import login_user, logout_user
 from forms import LoginForm, RegisterForm
 from models import db, User
+from helpers import clear_session
 
 landing_routes = Blueprint("landing_routes", __name__, static_folder="../static", template_folder="../templates/landing_page")
 
@@ -59,5 +60,6 @@ def logout():
     """Handle logout."""
 
     logout_user()
+    clear_session() # removes post draft data
 
     return redirect("/login")

--- a/static/group.css
+++ b/static/group.css
@@ -69,18 +69,15 @@
 .group-feed {
   display: grid;
   grid-template-rows: 5fr 1fr;
-  position: relative;
   box-sizing: border-box;
   background-color: #fff;
   height: 85vh;
   padding-top: 70px;
   margin-top: -50px;
   border-radius: 7px;
+  overflow-y: scroll;
   overflow-x: hidden;
   word-wrap: normal;
-  overflow-y: scroll;
-  -ms-overflow-style: none; /* for Internet Explorer, Edge */
-  scrollbar-width: none; /* for Firefox */
   z-index: 0;
 }
 
@@ -90,12 +87,13 @@
 
 /* feed portion where posts and comments will display */
 .feed {
-  grid-row: 1 / 2;
-  position: absolute;
-  bottom: 10px;
   display: flex;
   flex-direction: column;
   justify-content: flex-end;
+  grid-row: 1 / 2;
+  height: 100%;
+  width: 100%;
+  bottom: 10px;
   gap: 10px;
   padding: 10px;
 }
@@ -103,13 +101,14 @@
 /* input section for text area and buttons */
 .feed-post-creation {
   display: grid;
-  grid-template-columns: 70% 15% 15%;
+  grid-template-columns: 65% 15% 20%;
   position: sticky;
   bottom: 0;
   grid-row: 2 / 3;
   height: 110px;
   width: 100%;
   margin: auto;
+  margin-top: 10px;
   padding: 10px;
   border-radius: 6px;
 }
@@ -125,33 +124,81 @@
   resize: none;
   font-size: 16px;
   font-family: "Roboto", sans-serif;
-  padding: 10px;
+  padding: 15px;
   border-radius: 6px;
 }
 
-.feed-post-creation-btns {
-  grid-column: 3 / 4;
-  padding: 10px;
+.feed-post-creation-spotify img {
+  grid-template-columns: 2 / 3;
+  width: 88%;
+  border-radius: 6px;
+}
+
+.feed-post-creation-spotify .delete-img {
+  position: absolute;
+  text-align: center;
+  outline: 1px solid rgb(197, 0, 0);
+  border-radius: 10%;
+  z-index: 2;
 }
 
 .feed-post-creation button {
   grid-column: 2 / 3;
 }
 
+.post {
+  display: grid;
+  grid-template-columns: 55% 30% 12% 3%;
+  grid-template-rows: 30px 1fr;
+  width: 100%;
+}
+
 .post h4 {
+  grid-column: 1 / 4;
+  grid-row: 1 / 2;
   font-size: 0.9em;
   margin-top: 0;
   margin-bottom: 0;
-  background-color: rgb(231, 232, 240);
+  background-color: rgb(238, 240, 245);
   padding: 5px;
-  width: 100%;
+  width: 98%;
   border-radius: 4px;
 }
 
 .post p {
+  grid-column: 1 / 2;
+  grid-row: 2 / 3;
   font-size: 1em;
   margin: 2px 0 8px 0;
   padding-left: 5px;
+}
+
+.post img {
+  grid-column: 3 / 4;
+  grid-row: 2 / 3;
+  margin-top: 6px;
+  width: 100%;
+  min-width: 50px;
+  border-radius: 6px;
+}
+
+.post h5 {
+  font-size: 1em;
+  grid-column: 2 / 3;
+  grid-row: 2 / 3;
+  text-align: right;
+  margin: 6px 10px 5px 0;
+  line-height: 1.4em;
+}
+
+.post h5 .artist {
+  font-size: 0.9em;
+  font-weight: 100;
+}
+
+.post h5 .links span {
+  font-size: 0.75em;
+  font-style: italic;
 }
 
 .modal-bg {
@@ -231,7 +278,7 @@
 
 .spotify-search-res {
   display: grid;
-  grid-template-columns: 80px 1fr 200px;
+  grid-template-columns: 80px 1fr 100px;
   width: 100%;
 }
 
@@ -253,4 +300,20 @@
 .spotify-search-res h4 {
   font-size: 14px;
   margin: 10px;
+}
+
+.select-btn {
+  grid-template-columns: 2 / 3;
+  border: 1px solid #3d5588;
+  height: 40px;
+  width: 80px;
+}
+
+.select-btn:hover {
+  background-color: #3d5588;
+  color: #fff;
+}
+
+.selected {
+  border: 3px solid #1db954;
 }

--- a/static/group.js
+++ b/static/group.js
@@ -1,4 +1,4 @@
-// toggleDisabled disables the post button if the textarea is empty
+// toggleDisabled disables the post button if the textarea is empty. Group page.
 function toggleDisabled() {
   const button = document.querySelector(".post-btn");
   const input = document.querySelector("textarea");
@@ -13,5 +13,23 @@ function toggleDisabled() {
 }
 
 toggleDisabled();
+document.querySelector("textarea").addEventListener("keyup", toggleDisabled);
 
-document.querySelector("textarea").addEventListener("keypress", toggleDisabled);
+// removeSongFromPostCreation removes a song from the post creation form (jQuery). Group page.
+$trackImg = $("#selected-track-img");
+$trackImg.on("click", function () {
+  $("selected-track-img").hide();
+});
+
+$albumImgDiv = $("#feed-post-creation-spotify");
+$albumImgDiv.on("click", removeAlbumImg);
+
+function removeAlbumImg() {
+  $trackImg.hide();
+}
+
+// scroll to bottom of group page
+window.onload = () => {
+  const groupDiv = document.querySelector(".group-feed");
+  groupDiv.scrollTop = groupDiv.scrollHeight;
+};

--- a/templates/group_page/group.html
+++ b/templates/group_page/group.html
@@ -1,4 +1,3 @@
-
 {% extends 'header.html' %}
 <!-- -->
 {% block morestyle%}
@@ -7,7 +6,7 @@
 <!--  -->
 {% block morecontent %}
 <div class="left">
-  <a href="/user/{{ user.id }}/group/{{ group.id }}"><button class="back-btn">Back</button></a>
+  <a href="/user/{{ user.id }}"><button class="back-btn">Back</button></a>
   {% if group.admin_id != user.id %} {% if user_in_group %}
   <!-- non-admin buttons -->
   <form
@@ -52,34 +51,90 @@
     <div class="feed">
       {% for post in posts %}
       <div class="post">
-        <p>
-          <h4>{{ user.username }}</h4>
-          <p>{{ post.content }} </p>
-        </p>
+        <h4>{{ post.user.username }}</h4>
+        <br />
+        <p>{{ post.content }}</p>
+        {% if post.s_name %}
+        <img
+          src="{{ post.s_image }}"
+          alt="{{ session['track_name'] }} album image"
+        />
+        <h5>
+          {{ post.s_name }}
+          <div class="artist">{{ post.s_artist }}</div>
+          <div class="links">
+            <span
+              ><a href="{{ post.s_preview }}" target="_blank"
+                >Preview &nbsp;<i class="far fa-play-circle"></i></a
+            ></span>
+            |
+            <span
+              ><a href="{{ post.s_link }}" target="_blank"
+                >View on Spotify</a
+              ></span
+            >
+          </div>
+        </h5>
+        {% endif %}
       </div>
       {% endfor %}
     </div>
     <div class="feed-post-creation">
       <div class="feed-post-creation-input">
-        <form method="POST" novalidate="True" id="post-form">
-          {{ form.hidden_tag() }}
+        <form
+          action="/user/{{ user.id }}/group/{{ group.id }}/post"
+          method="POST"
+          novalidate="True"
+          id="post-form"
+        >
+          {{ post_form.hidden_tag() }}
           <!--  -->
-          {{ form.content }}
+          {{ post_form.content }}
           <!--  -->
         </form>
       </div>
+      <div class="feed-post-creation-spotify">
+        {% if session['track_name'] %}
+        <div class="delete-img">
+          <form
+            action="/user/{{ user.id }}/group/{{ group.id }}"
+            method="POST"
+            novalidate="True"
+          >
+            <button type="submit" name="btn" value="delete">
+              <i class="fas fa-trash-alt"></i>
+            </button>
+          </form>
+        </div>
+        <img
+          id="selected-track-img"
+          src="{{ session['track_image'] }}"
+          alt="{{ session['track_title'] }} album image"
+        />
+        {% endif %}
+      </div>
       <div class="feed-post-creation-btns">
         <form action="/user/{{ user.id }}/group/{{ group.id }}/search_spotify">
-          <button type="submit" class="spotify-btn" onclick="{{ session.pop('track_results', None) }}">Search Spotify</button>
+          <button
+            type="submit"
+            class="spotify-btn"
+            onclick="{{ session.pop('track_results', None) }}"
+          >
+            Search Spotify
+          </button>
         </form>
         <button form="post-form" type="submit" class="post-btn">Post</button>
       </div>
     </div>
   </div>
-{% block spotify %} {% endblock %}
+  {% block spotify %} {% endblock %}
 </div>
 <div class="right"></div>
-{% block script %} 
-  <script src="/static/group.js"></script>
-{% endblock %}
-{% endblock %}
+{% block script %}
+<script src="/static/group.js"></script>
+<script
+  src="https://code.jquery.com/jquery-3.6.0.js"
+  integrity="sha256-H+K7U5CnXl1h5ywQfKtSj8PCmoN9aaq30gDh27Xc0jk="
+  crossorigin="anonymous"
+></script>
+{% endblock %} {% endblock %}

--- a/templates/group_page/search_spotify.html
+++ b/templates/group_page/search_spotify.html
@@ -6,11 +6,13 @@
 </div>
 <div class="spotify-search-modal">
   <form method="POST" novalidate="True" id="spotify-search-form">
-    {{ form.hidden_tag() }}
+    {{ search_form.hidden_tag() }}
     <!--  -->
-    {{ form.query(placeholder="Search for songs") }}
+    {{ search_form.query(placeholder="Search for songs") }}
     <!--  -->
-    <button type="submit" class="post-btn">Search</button>
+    <button type="submit" class="post-btn" name="btn" value="search">
+      Search
+    </button>
   </form>
   <div class="spotify-search-results">
     {% for track in tracks %}
@@ -43,6 +45,37 @@
           >
         </h4>
       </div>
+      <form
+        action="/user/{{ user.id }}/group/{{ group.id }}/search_spotify"
+        method="POST"
+        novalidate="True"
+        id="select-song-form"
+      >
+        <input
+          type="hidden"
+          name="track_image"
+          value="{{ track['album']['images'][1]['url'] }}"
+        />
+        <input type="hidden" name="track_name" value="{{ track['name'] }}" />
+        <input
+          type="hidden"
+          name="track_artist"
+          value="{{ track['artists'][0]['name'] }}"
+        />
+        <input
+          type="hidden"
+          name="track_link"
+          value="{{ track['external_urls']['spotify'] }}"
+        />
+        <input
+          type="hidden"
+          name="track_preview"
+          value="{{ track['preview_url'] }}"
+        />
+        <button type="submit" class="select-btn" name="btn" value="select">
+          Select
+        </button>
+      </form>
     </div>
     {% endfor %}
   </div>


### PR DESCRIPTION
### What does this PR do?
Users can select songs from the spotify-search window and add them to their group posts.
A selected song is added to the Flask session.
Posting a song sends a post request to <i>/user/<user_id>/group/<group_id>/post</i>.
If the post includes Flask-session data, the post will include the song information.

### Description of task to be completed
- Closes #50 

### How to test
- Navigate to root directory and run <code>python3 -m unittest tests/test_group_routes.py</code> in terminal.