### PR TITLE
Add most-liked-songs section to groups

### DIFF
--- a/models.py
+++ b/models.py
@@ -1,6 +1,7 @@
 from flask_sqlalchemy import SQLAlchemy
 from flask_bcrypt import Bcrypt
 from sqlalchemy.orm import backref
+from sqlalchemy.ext.hybrid import hybrid_property
 
 bcrypt = Bcrypt()
 db = SQLAlchemy()
@@ -92,6 +93,10 @@ class Post(db.Model):
 
     user = db.relationship('User', backref=backref('posts', cascade='all, delete-orphan'))
     likes = db.relationship('Likes', backref=backref('posts', single_parent=True))
+
+    @hybrid_property
+    def likes_count(self):
+        return self.likes.count()
 
 
 class Likes(db.Model):

--- a/static/group.css
+++ b/static/group.css
@@ -287,3 +287,59 @@
 .selected {
   border: 3px solid #1db954;
 }
+
+/* right */
+
+.most-liked {
+  height: 60%;
+  margin-top: 25px;
+  padding: 22px;
+}
+
+.most-liked h2 {
+  background-color: #fff;
+  text-align: center;
+  padding: 10px;
+  border-radius: 5px;
+  -webkit-box-shadow: 0 10px 3px -8px rgba(0, 0, 0, 0.8);
+  -moz-box-shadow: 0 10px 3px -8px rgba(0, 0, 0, 0.8);
+  box-shadow: 0 10px 3px -8px rgba(0, 0, 0, 0.8);
+}
+
+.most-liked-feed {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  height: 60vh;
+}
+
+.most-liked-feed .recommendation {
+  display: grid;
+  grid-template-columns: 60px 1fr;
+  width: 100%;
+  margin: 5px 0 5px 0;
+}
+
+.most-liked-feed h4 {
+  display: inline;
+  vertical-align: top;
+  margin: 0;
+  padding: 0;
+  word-wrap: normal;
+}
+
+.most-liked-feed img {
+  display: inline;
+  width: 50px;
+  border-radius: 3px;
+}
+
+.rec-info .rec-artist {
+  font-size: 0.8em;
+}
+
+.rec-info p {
+  font-size: 0.8em;
+  font-weight: bold;
+  margin-top: 5px;
+}

--- a/templates/group_page/group.html
+++ b/templates/group_page/group.html
@@ -79,9 +79,8 @@
             {% endif %}
           </span>
           <span class="likes-count"
-            >{% endif %} {% if post.likes|length == 1 %}1 like{% elif
-            post.likes|length > 1%}{{ post.likes|length }} likes{% endif
-            %}</span
+            >{% endif %} {% if post.likes|count == 1 %}1 like{% elif
+            post.likes|count > 1%}{{ post.likes|count }} likes{% endif %}</span
           >
         </h4>
         <br />
@@ -161,7 +160,31 @@
   </div>
   {% block spotify %} {% endblock %}
 </div>
-<div class="right"></div>
+<div class="right">
+  <div class="most-liked">
+    <h2>Top recommended</h2>
+    <div class="most-liked-feed">
+      {% for song in top_recommended %}
+      <div class="recommendation">
+        <div class="rec-image">
+          <a href="{{ song.s_link }}" target="_blank"
+            ><img src="{{ song.s_image }}" alt="{{ song.s_name }} album image"
+          /></a>
+        </div>
+        <div class="rec-info">
+          <a href="{{ song.s_link }}" target="_blank"
+            ><h4>
+              {{ song.s_name }} <b>-</b>
+              <span class="rec-artist">{{ song.s_artist }}</span>
+            </h4></a
+          >
+          <p>{{ song.likes|count }} &nbsp;<i class="far fa-heart"></i></p>
+        </div>
+      </div>
+      {% endfor %}
+    </div>
+  </div>
+</div>
 {% block script %}
 <script src="/static/group.js"></script>
 <script


### PR DESCRIPTION
### What does this PR do?
- Adds a section in group pages that displays the top 5 most-liked songs recommended in that group.

### Description of task to be completed
- Closes #61 

### How to test
- Navigate to root directory and run <code>python3 -m unittest tests/test_group_routes.py</code> in terminal.