### PR TITLE
add group description and member count displays

### DIFF
--- a/routes/group_routes.py
+++ b/routes/group_routes.py
@@ -21,6 +21,7 @@ def group_page(user_id, group_id):
     user = User.query.get(user_id)
     group = Group.query.get(group_id)
     user_in_group = UserGroup.query.filter(UserGroup.user_id == user_id, UserGroup.group_id == group_id).first() # determine if user is in group (but not admin). Used to choose which action buttons to display.
+    group_user_count = UserGroup.query.filter(UserGroup.group_id == group_id).count() # number of users in group
 
     posts = Post.query.filter(Post.group_id == group_id).all()
     top_recommended = Post.query.join(Likes).filter(Post.group_id == group_id, Post.s_name != None).group_by(Post.id).order_by(func.count().desc()).limit(5).all()
@@ -31,7 +32,7 @@ def group_page(user_id, group_id):
     if request.method == 'POST' and request.form["btn"] == "delete":
         clear_session()
 
-    return render_template("group.html", user=user, group=group, user_in_group=user_in_group, posts=posts, post_form=post_form, top_recommended=top_recommended, clear_session=clear_session)
+    return render_template("group.html", user=user, group=group, user_in_group=user_in_group, group_user_count=group_user_count, posts=posts, post_form=post_form, top_recommended=top_recommended, clear_session=clear_session)
 
 
 @group_routes.route("/user/<int:user_id>/group/<int:group_id>/post", methods=["POST"])

--- a/static/group.css
+++ b/static/group.css
@@ -1,4 +1,14 @@
-.center {
+.member-count {
+  margin: 30px 0 15px 15px;
+  font-size: 1.2em;
+}
+
+.description {
+  margin: 0 0 15px 15px;
+  font-size: 0.8em;
+}
+
+.artist {
   box-sizing: border-box;
 }
 

--- a/templates/group_page/group.html
+++ b/templates/group_page/group.html
@@ -41,6 +41,15 @@
     <button type="submit" class="delete-btn">Delete group</button>
   </form>
   {% endif %}
+  <div class="member-count">
+    <h2>
+      {{ group_user_count }}{% if group_user_count == 1 %} member{% else %}
+      members{% endif %}
+    </h2>
+  </div>
+  <div class="description">
+    <h3>{{ group.description }}</h3>
+  </div>
 </div>
 <!--  -->
 <div class="center">
@@ -76,11 +85,8 @@
                 <i class="fas fa-heart"></i>
               </button>
             </form>
+            {% endif %}
           </span>
-          <span class="likes-count"
-            >{% endif %} {% if post.likes|count == 1 %}1 like{% elif
-            post.likes|count > 1%}{{ post.likes|count }} likes{% endif %}</span
-          >
           <!--  -->
           {% else %}
           <form
@@ -93,6 +99,10 @@
             </button>
           </form>
           {% endif %}
+          <span class="likes-count"
+            >{% if post.likes|count == 1 %}1 like{% elif post.likes|count >
+            1%}{{ post.likes|count }} likes{% endif %}</span
+          >
         </h4>
         <br />
         <p>{{ post.content }}</p>

--- a/templates/user_page/browse-groups.html
+++ b/templates/user_page/browse-groups.html
@@ -17,7 +17,6 @@
     <div class="group-badge">
       <a href="/user/{{ user.id }}/group/{{ group.id }}">
         <h3>{{ group.name}}</h3>
-        <h4>_ members</h4>
         <p>{{ group.description }}</p>
       </a>
     </div>

--- a/templates/user_page/user-page.html
+++ b/templates/user_page/user-page.html
@@ -29,7 +29,7 @@
       {% for group in created_groups %}
       <a href="/user/{{ user.id }}/group/{{ group.id }}" class="group-tile"
         ><h3>{{ group.name}}</h3>
-        <h4>_ members</h4>
+        <h4>{{ group.description }}</h4>
       </a>
       {% endfor %}
     </div>
@@ -42,7 +42,7 @@
       {% for group in joined_groups %}
       <a href="/user/{{ user.id }}/group/{{ group.id }}" class="group-tile"
         ><h3>{{ group.name}}</h3>
-        <h4>_ members</h4>
+        <h4>{{ group.description }}</h4>
       </a>
       {% endfor %}
     </div>

--- a/tests/test_group_routes.py
+++ b/tests/test_group_routes.py
@@ -31,6 +31,10 @@ class TestGroupRoutes(TestCase):
         db.session.add(self.test_group)
         db.session.commit()
 
+        self.test_user_group = UserGroup(user_id=1, group_id=1)
+        db.session.add(self.test_user_group)
+        db.session.commit()
+
     def tearDown(self):
         db.session.rollback()
         return super().tearDown()
@@ -59,7 +63,9 @@ class TestGroupRoutes(TestCase):
             html = resp.get_data(as_text=True)
 
             self.assertEqual(resp.status_code, 200)
-            self.assertIn("Test Group</h1>", html)
+            self.assertIn("Test Group", html)
+            self.assertIn("A group for testing", html)
+            self.assertIn("1 member", html)
 
 
     def test_admin_group_view(self):

--- a/tests/test_user_routes.py
+++ b/tests/test_user_routes.py
@@ -55,6 +55,7 @@ class TestUserRoutes(TestCase):
 
             self.assertIn('<h3>Test Group 2</h3>', html)
             self.assertIn('<h3>Test Group</h3', html)
+            self.assertIn('A group for testing', html)
 
             self.assertIn('<h2>Recent recommendations</h2>', html)
             self.assertIn('song_name', html)


### PR DESCRIPTION
### What does this PR do?
- Adds description and member count to group page on left hand side.
- On user routes, group tiles show description under group name.

### Description of task to be completed
- Closes #73 

### How to test
- Navigate to root directory and run `python3 -m unittest tests/test_group_routes.py` in terminal.
- Navigate to root directory and run `python3 -m unittest tests/test_user_routes.py` in terminal.
- Tests added in page-display test sections.